### PR TITLE
Various code and UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # espsegs
 
 ```
-Usage: espsegs.exe --chip <CHIP> <FILE>
+Usage: espsegs [OPTIONS] --chip <CHIP> <FILE>
 
 Arguments:
   <FILE>
 
 Options:
   -c, --chip <CHIP>
-  -h, --help         Print help
-  -V, --version      Print version
+  -s, --flash-size <SIZE>  [possible values: 256KB, 512KB, 1MB, 2MB, 4MB, 8MB, 16MB, 32MB, 64MB, 128MB, 256MB]
+  -w, --width <WIDTH>      [default: 120]
+  -h, --help               Print help (see more with '--help')
+  -V, --version            Print version
 
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,8 @@ fn print_memory(
         ((width as f64 / region_size as f64) * (block_start as f64 - region_start as f64)) as usize;
     let w = ((width as f64 / region_size as f64) * block_size as f64) as usize;
 
-    let (small, w) = if w == 0 { (true, 1) } else { (false, w) };
+    let small = w == 0;
+    let w = w.max(1);
 
     print!("[");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let mut last_region = usize::MAX;
+
+    // Calculate max section name width for the first column
+    let mut section_name_max_width = 0;
+    for section in sections.iter() {
+        let name = section.name().unwrap();
+        if name.len() > section_name_max_width {
+            section_name_max_width = name.len();
+        }
+    }
+
     for section in sections {
         let region = chip_memory.regions.iter().find(|region| {
             region.start <= section.address()
@@ -102,10 +112,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         print!(
-            "{:<12.12} {:8x} {:7}",
+            "{:width$} {:8x} {:7}",
             section.name().unwrap(),
             section.address(),
-            section.size()
+            section.size(),
+            width = section_name_max_width,
         );
 
         if let Some(ref region) = &region {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,13 +121,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
 
         if let Some(ref region) = &region {
+            print!(" {:5} ", region.name);
             print_memory(
-                region.name,
                 region.start,
                 region.end(args.flash_size),
                 section.address(),
                 section.size(),
-                args.width,
+                args.width - section_name_max_width - 26, // 26 = `address` + `size` + spaces + brackets + region name
             );
         }
 
@@ -138,14 +138,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn print_memory(
-    region_name: &str,
     region_start: u64,
     region_end: u64,
     block_start: u64,
     block_size: u64,
     width: usize,
 ) {
-    print!(" {:5} ", region_name);
     let region_size = region_end - region_start;
     let offset =
         ((width as f64 / region_size as f64) * (block_start as f64 - region_start as f64)) as usize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,11 @@ struct Args {
     file: PathBuf,
     #[arg(short, long)]
     chip: String,
+
+}
+
+fn normalize(chip_name: &str) -> String {
+    chip_name.replace("-", "").to_ascii_lowercase()
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -26,10 +31,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .collect();
     sections.sort_by(|a, b| a.address().partial_cmp(&b.address()).unwrap());
 
-    let chip = args.chip.replace("-", "").to_ascii_lowercase();
-    let chip_memory = MEMORY
-        .iter()
-        .find(|m| m.name.replace("-", "").to_ascii_lowercase() == chip);
+    let chip = normalize(&args.chip);
+    let chip_memory = MEMORY.iter().find(|m| normalize(&m.name) == chip);
 
     if let None = chip_memory {
         println!("Unknown chip");

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,12 +34,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let chip = normalize(&args.chip);
     let chip_memory = MEMORY.iter().find(|m| normalize(&m.name) == chip);
 
-    if let None = chip_memory {
+    let Some(chip_memory) = chip_memory else {
         println!("Unknown chip");
         exit(1);
-    }
-
-    let chip_memory = chip_memory.unwrap();
+    };
 
     let mut last_region = usize::MAX;
 


### PR DESCRIPTION
This PR:
 - cleans up some duplicate code
 - adds flash size and width parameters
 - setting the width now specifies the total display width, not just the memory graph
 - section names are no longer truncated
 - memory regions are now defined by their start address and length. I'm not married to this, but it felt a bit more natural while writing the flash size bits, and it's still possible to derive this from the region end.

The readme's graph is now slightly incorrect but I hope that's not a big issue.

Closes #2